### PR TITLE
COMP: Escape @article in doxygen comments.

### DIFF
--- a/include/itkMorphologicalSharpeningImageFilter.h
+++ b/include/itkMorphologicalSharpeningImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  * made to minimize memory consumption.
  *
  *
- * @article{Schavemaker2000,
+ * \@article{Schavemaker2000,
  *  author    = {Schavemaker, J. and Reinders, M. and Gerbrands, J. and Backer, E.
 },
  * title     = {Image sharpening by morphological filtering},


### PR DESCRIPTION
The BibTeX entry is interpreted as an unknown Doxygen command and generates:

  for
  ITK/Modules/Remote/ParabolicMorphology/include/itkMorphologicalSharpeningImageFilter.h:37:
  warning: Found unknown command `\article'