### PR TITLE
BUG: Missing typename

### DIFF
--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
@@ -35,7 +35,7 @@ ParabolicOpenCloseSafeBorderImageFilter< TInputImage, doOpen, TOutputImage >
   // Allocate the output
   this->AllocateOutputs();
   InputImageConstPointer inputImage;
-  PadFilterType::SizeType Bounds;
+  typename PadFilterType::SizeType Bounds;
   typename PadFilterType::SizeType BoundsSize;
   if ( this->m_SafeBorder )
     {


### PR DESCRIPTION
Missing typename introduced by previous commit that changed a variable type
to correct a compilation problem on Windows [1].

[1] 9cef2f0c57dda71406c6c030eaa087ad7fb1ecbe