### PR TITLE
BUG: Fix memory leaks by moving `progress` from the heap to the stack

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -211,13 +211,12 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
   }
     float progressPerDimension = 1.0 / ImageDimension;
 
-    auto *progress = new ProgressReporter(this,
-                                          threadId,
-                                          NumberOfRows[m_CurrentDimension],
-                                          30,
-                                          m_CurrentDimension * progressPerDimension,
-                                          progressPerDimension);
-
+    ProgressReporter progress(this,
+                              threadId,
+                              NumberOfRows[m_CurrentDimension],
+                              30,
+                              m_CurrentDimension * progressPerDimension,
+                              progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex<TInputImage>;
   using OutputIteratorType = ImageLinearIteratorWithIndex<TOutputImage>;
@@ -252,7 +251,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
       doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doDilate>(
         inputIterator,
         outputIterator,
-        *progress,
+        progress,
         LineLength,
         0,
         this->m_MagnitudeSign,
@@ -291,7 +290,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
       doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doDilate>(
         inputIteratorStage2,
         outputIterator,
-        *progress,
+        progress,
         LineLength,
         m_CurrentDimension,
         this->m_MagnitudeSign,

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -282,12 +282,12 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
     }
     float progressPerDimension = 1.0 / ImageDimension;
 
-    auto *progress = new ProgressReporter(this,
-                                          threadId,
-                                          NumberOfRows[m_CurrentDimension],
-                                          30,
-                                          m_CurrentDimension * progressPerDimension,
-                                          progressPerDimension);
+    ProgressReporter progress(this,
+                              threadId,
+                              NumberOfRows[m_CurrentDimension],
+                              30,
+                              m_CurrentDimension * progressPerDimension,
+                              progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex<TInputImage>;
   using OutputIteratorType = ImageLinearIteratorWithIndex<TOutputImage>;
@@ -326,7 +326,7 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
         doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !DoOpen>(
           inputIterator,
           outputIterator,
-          *progress,
+          progress,
           LineLength,
           0,
           this->m_MagnitudeSign,
@@ -363,7 +363,7 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
         doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !DoOpen>(
           inputIteratorStage2,
           outputIterator,
-          *progress,
+          progress,
           LineLength,
           m_CurrentDimension,
           this->m_MagnitudeSign,
@@ -387,7 +387,7 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
       doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, DoOpen>(
         inputIteratorStage2,
         outputIterator,
-        *progress,
+        progress,
         LineLength,
         m_CurrentDimension,
         this->m_MagnitudeSign,


### PR DESCRIPTION
Declaring those two local `ProgressReporter` objects on the stack (instead of on the heap) may benefit run-time performance. But moreover, it fixes two memory leaks (missing `delete progress`).